### PR TITLE
Fix #14

### DIFF
--- a/lib/active_admin/axlsx.rb
+++ b/lib/active_admin/axlsx.rb
@@ -18,8 +18,11 @@ class Railtie < ::Rails::Railtie
 
     ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Axlsx::DSL
     ActiveAdmin::Resource.send :include, ActiveAdmin::Axlsx::ResourceExtension
-    ActiveAdmin::ResourceController.send :include, ActiveAdmin::Axlsx::ResourceControllerExtension
     ActiveAdmin::Views::PaginatedCollection.add_format :xlsx
+  end
+
+  config.after_initialize do
+    ActiveAdmin::ResourceController.send :include, ActiveAdmin::Axlsx::ResourceControllerExtension
   end
 end
 


### PR DESCRIPTION
I don't know why, but it just works.

I've found that if I move [this line](https://github.com/randym/activeadmin-axlsx/blob/master/lib/active_admin/axlsx.rb#L21) to a separate initializer in my rails app, it will work. So I could just assume that if this line is executed after the initializing of ActiveAdmin, it will probably work. And it did.
