### PR TITLE
Ability to execute controller's view_context methods in column builder block

### DIFF
--- a/lib/active_admin/axlsx/builder.rb
+++ b/lib/active_admin/axlsx/builder.rb
@@ -128,8 +128,9 @@ module ActiveAdmin
 
       # Serializes the collection provided
       # @return [Axlsx::Package]
-      def serialize(collection)
+      def serialize(collection, view_context)
         @collection = collection
+        @view_context = view_context
         apply_filter @before_filter
         export_collection(collection)
         apply_filter @after_filter
@@ -221,6 +222,14 @@ module ActiveAdmin
       def resource_columns(resource)
         [Column.new(:id)] + resource.content_columns.map do |column|
           Column.new(column.name.to_sym)
+        end
+      end
+
+      def method_missing(method_name, *arguments)
+        if @view_context.respond_to? method_name
+          @view_context.send method_name, *arguments
+        else
+          super
         end
       end
     end

--- a/lib/active_admin/axlsx/builder.rb
+++ b/lib/active_admin/axlsx/builder.rb
@@ -42,7 +42,8 @@ module ActiveAdmin
       #   @see ActiveAdmin::Axlsx::DSL
       def initialize(resource_class, options={}, &block)
         @skip_header = false
-        @columns = resource_columns(resource_class)
+        @resource_class = resource_class
+        @columns = resource_columns(@resource_class)
         parse_options options
         instance_eval &block if block_given?
       end
@@ -117,7 +118,7 @@ module ActiveAdmin
       # @param [Proc] block A block of code that is executed on the resource
       #                     when generating row data for this column.
       def column(name, &block)
-        @columns << Column.new(name, block)
+        @columns << Column.new(name, @resource_class, block)
       end
 
       # removes columns by name
@@ -141,16 +142,20 @@ module ActiveAdmin
 
       class Column
 
-        def initialize(name, block = nil)
-          @name = name.to_sym
+        def initialize(name, resource_class = nil, block = nil)
+          @name = name
+          @resource_class = resource_class
           @data = block || @name
         end
 
         attr_reader :name, :data
 
         def localized_name(i18n_scope = nil)
-          return name.to_s.titleize unless i18n_scope
-          I18n.t name, scope: i18n_scope
+          if i18n_scope
+            I18n.t name, scope: i18n_scope
+          else
+            name.is_a?(Symbol) && @resource_class.present? ? @resource_class.human_attribute_name(name) : name.to_s.humanize
+          end
         end
       end
 
@@ -220,8 +225,8 @@ module ActiveAdmin
       end
 
       def resource_columns(resource)
-        [Column.new(:id)] + resource.content_columns.map do |column|
-          Column.new(column.name.to_sym)
+        [Column.new(:id, @resource_class)] + resource.content_columns.map do |column|
+          Column.new(column.name.to_sym, @resource_class)
         end
       end
 

--- a/lib/active_admin/axlsx/resource_controller_extension.rb
+++ b/lib/active_admin/axlsx/resource_controller_extension.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       def index_with_xlsx(options={}, &block)
         index_without_xlsx(options) do |format|
            format.xlsx do
-            xlsx = active_admin_config.xlsx_builder.serialize(collection)
+            xlsx = active_admin_config.xlsx_builder.serialize(collection, view_context)
             send_data xlsx, :filename => "#{xlsx_filename}", :type => Mime::Type.lookup_by_extension(:xlsx)
           end
         end


### PR DESCRIPTION
Currently `Axml::Builder` behaviour is not exactly the same as `CSVBuilder` logic.
`Axml::Builder`  does not have access to controller's `view_context` in column proc, but `CSVBuilder` does.
Let's fix it.

Code example:

``` ruby
xlsx do
  clear_columns
  column :date do |v|
    # HERE! format_date (helper method defined in controller) is not accessible
    format_date v.date
  end
end

csv do
  column :date do |v|
    format_date v.date # but it is accessible here
  end
end

index do
  column :date do |v|
    format_date v.date # and of course here
  end
end

controller do
  helper_method :format_date

  def format_date date
    # some helper method in controller
    case params[:grouping]
      when 'by_day' then date.strftime '%d.%m.%Y'
      when 'by_month' then date.strftime '%B %Y'
    end
  end
end
```
