### PR TITLE
Ability to execute controller's view_context methods in column builder block

### DIFF
--- a/lib/active_admin/axlsx/builder.rb
+++ b/lib/active_admin/axlsx/builder.rb
@@ -128,8 +128,9 @@ module ActiveAdmin
 
       # Serializes the collection provided
       # @return [Axlsx::Package]
-      def serialize(collection)
+      def serialize(collection, view_context)
         @collection = collection
+        @view_context = view_context
         apply_filter @before_filter
         export_collection(collection)
         apply_filter @after_filter
@@ -221,6 +222,14 @@ module ActiveAdmin
       def resource_columns(resource)
         [Column.new(:id)] + resource.content_columns.map do |column|
           Column.new(column.name.to_sym)
+        end
+      end
+
+      def method_missing(method_name, *arguments)
+        if @view_context.respond_to? method_name
+          @view_context.send method_name, *arguments
+        else
+          super
         end
       end
     end

--- a/lib/active_admin/axlsx/resource_controller_extension.rb
+++ b/lib/active_admin/axlsx/resource_controller_extension.rb
@@ -11,7 +11,7 @@ module ActiveAdmin
       def index_with_xlsx(options={}, &block)
         index_without_xlsx(options) do |format|
            format.xlsx do
-            xlsx = active_admin_config.xlsx_builder.serialize(collection)
+            xlsx = active_admin_config.xlsx_builder.serialize(collection, view_context)
             send_data xlsx, :filename => "#{xlsx_filename}", :type => Mime::Type.lookup_by_extension(:xlsx)
           end
         end


### PR DESCRIPTION
Currently `Axml::Builder` behaviour is not exactly the same as `CSVBuilder` logic.
`Axml::Builder`  does not have access to controller's `view_context` in column proc, but `CSVBuilder` does.
Let's fix it.

Code example:

``` ruby
xlsx do
  clear_columns
  column :date do |v|
    # HERE! format_date (helper method defined in controller) is not accessible
    format_date v.date
  end
end

csv do
  column :date do |v|
    format_date v.date # but it is accessible here
  end
end

index do
  column :date do |v|
    format_date v.date # and of course here
  end
end

controller do
  helper_method :format_date

  def format_date date
    # some helper method in controller
    case params[:grouping]
      when 'by_day' then date.strftime '%d.%m.%Y'
      when 'by_month' then date.strftime '%B %Y'
    end
  end
end
```
