### PR TITLE
Delay the initialization of resource columns until needed

### DIFF
--- a/lib/active_admin/axlsx/builder.rb
+++ b/lib/active_admin/axlsx/builder.rb
@@ -42,7 +42,8 @@ module ActiveAdmin
       #   @see ActiveAdmin::Axlsx::DSL
       def initialize(resource_class, options={}, &block)
         @skip_header = false
-        @columns = resource_columns(resource_class)
+        @resource_class = resource_class
+        @columns = []
         parse_options options
         instance_eval &block if block_given?
       end
@@ -74,7 +75,7 @@ module ActiveAdmin
 
       # This is the I18n scope that will be used when looking up your
       # colum names in the current I18n locale.
-      # If you set it to [:active_admin, :resources, :posts] the 
+      # If you set it to [:active_admin, :resources, :posts] the
       # serializer will render the value at active_admin.resources.posts.title in the
       # current translations
       # @note If you do not set this, the column name will be titleized.
@@ -92,8 +93,9 @@ module ActiveAdmin
         @before_filter = block
       end
 
-      # The columns this builder will be serializing
-      attr_reader :columns
+      def columns
+        @columns ||= resource_columns(@resource_class)
+      end
 
       # The collection we are serializing.
       # @note This is only available after serialize has been called,


### PR DESCRIPTION
At the point of initialization, when running migrations and the table did not exist for the resource
class at that point, it would fail with the following error:

```
ActiveRecord::StatementInvalid: <database-adapter>::UndefinedTable: ERROR:  relation
"<table-name-for-model>" does not exist
```

The inspiration for this fix came from https://github.com/randym/activeadmin-axlsx/pull/35
